### PR TITLE
Make float dtypes work

### DIFF
--- a/eubi_bridge/base/data_manager.py
+++ b/eubi_bridge/base/data_manager.py
@@ -200,8 +200,8 @@ def create_ome_xml( # make 5D omexml
         "int8": PixelType.INT8,
         "int16": PixelType.INT16,
         "int32": PixelType.INT32,
-        "float": PixelType.FLOAT,
-        "double": PixelType.DOUBLE,
+        "float32": PixelType.FLOAT,
+        "float64": PixelType.DOUBLE,
     }
 
     if dtype not in dtype_map:

--- a/eubi_bridge/ngff/multiscales.py
+++ b/eubi_bridge/ngff/multiscales.py
@@ -305,10 +305,9 @@ class NGFFMetadataHandler:
                     dtype = None) -> None:
         """Add a channel to the OMERO metadata."""
 
-        # import numpy as np
         assert dtype is not None
         min = 0
-        max = np.iinfo(dtype).max
+        max = np.iinfo(dtype).max if np.issubdtype(dtype, np.integer) else np.finfo(dtype).max
         
         if 'omero' not in self.metadata:
             self.metadata['omero'] = {


### PR DESCRIPTION
Trying to convert a float image currently fails due to the `numpy.iinfo` lookup and the pixel type mapping, this PR fixes it

Reproduce:
```py
import numpy
import tifffile
data = numpy.random.randint(0,255,(25,25,25)).astype(numpy.float64)
tifffile.imwrite("test_float_img.tif", data)
```

CLI:
```
eubi to_zarr test_float_img.tif test_output
```

```pytb
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "C:\Users\me\.conda\envs\eubi\Scripts\eubi.exe\__main__.py", line 7, in <module>
    sys.exit(main())
             ^^^^^^
  File "C:\Users\me\Code\EuBI-Bridge\eubi_bridge\cli.py", line 18, in main
    fire.Fire(EuBIBridge)
  File "C:\Users\me\.conda\envs\eubi\Lib\site-packages\fire\core.py", line 135, in Fire
    component_trace = _Fire(component, args, parsed_flag_args, context, name)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\me\.conda\envs\eubi\Lib\site-packages\fire\core.py", line 468, in _Fire
    component, remaining_args = _CallAndUpdateTrace(
                                ^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\me\.conda\envs\eubi\Lib\site-packages\fire\core.py", line 684, in _CallAndUpdateTrace
    component = fn(*varargs, **kwargs)
                ^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\me\Code\EuBI-Bridge\eubi_bridge\ebridge.py", line 756, in to_zarr
    self.base_results = base.write_arrays(output_path,
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\me\Code\EuBI-Bridge\eubi_bridge\ebridge_base.py", line 479, in write_arrays
    storage_results = store_arrays(
                      ^^^^^^^^^^^^^
  File "C:\Users\me\Code\EuBI-Bridge\eubi_bridge\base\writers.py", line 553, in store_arrays
    meta.add_channel(color = channel['color'],
  File "C:\Users\me\Code\EuBI-Bridge\eubi_bridge\ngff\multiscales.py", line 311, in add_channel
    max = np.iinfo(dtype).max# if np.issubdtype(dtype, numpy.integer) else np.finfo(dtype).max
          ^^^^^^^^^^^^^^^
  File "C:\Users\me\.conda\envs\eubi\Lib\site-packages\numpy\_core\getlimits.py", line 707, in __init__
    raise ValueError(f"Invalid integer data type {self.kind!r}.")
ValueError: Invalid integer data type 'f'.
```

And after fixing this one:
```pytb
Traceback (most recent call last):
  File "C:\Users\me\Code\EuBI-Bridge\eubi_bridge\cli.py", line 22, in <module>
    main()
  File "C:\Users\me\Code\EuBI-Bridge\eubi_bridge\cli.py", line 18, in main
    fire.Fire(EuBIBridge)
  File "C:\Users\me\.conda\envs\eubi\Lib\site-packages\fire\core.py", line 135, in Fire
    component_trace = _Fire(component, args, parsed_flag_args, context, name)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\me\.conda\envs\eubi\Lib\site-packages\fire\core.py", line 468, in _Fire
    component, remaining_args = _CallAndUpdateTrace(
                                ^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\me\.conda\envs\eubi\Lib\site-packages\fire\core.py", line 684, in _CallAndUpdateTrace
    component = fn(*varargs, **kwargs)
                ^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\me\Code\EuBI-Bridge\eubi_bridge\ebridge.py", line 756, in to_zarr
    self.base_results = base.write_arrays(output_path,
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\me\Code\EuBI-Bridge\eubi_bridge\ebridge_base.py", line 506, in write_arrays
    manager.create_omemeta()
  File "C:\Users\me\Code\EuBI-Bridge\eubi_bridge\base\data_manager.py", line 656, in create_omemeta
    self.omemeta = create_ome_xml(image_shape = self.array.shape,
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\me\Code\EuBI-Bridge\eubi_bridge\base\data_manager.py", line 209, in create_ome_xml
    raise ValueError(f"Unsupported dtype: {dtype}")
ValueError: Unsupported dtype: float64
```